### PR TITLE
Removing the master and slave words

### DIFF
--- a/automatic/myapp/migrations/0003_auto_20190627_1613.py
+++ b/automatic/myapp/migrations/0003_auto_20190627_1613.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='db_instance',
             name='type',
-            field=models.CharField(choices=[('master', '主库'), ('slave', '从库')], default='', max_length=6),
+            field=models.CharField(choices=[('main', '主库'), ('subordinate', '从库')], default='', max_length=6),
             preserve_default=False,
         ),
         migrations.AddField(

--- a/automatic/myapp/migrations/0004_auto_20190923_1108.py
+++ b/automatic/myapp/migrations/0004_auto_20190923_1108.py
@@ -85,7 +85,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='db_instance',
             name='type',
-            field=models.CharField(choices=[('master', '主库'), ('slave', '从库'), ('alone', '单机')], default='', max_length=6, verbose_name='实例类型'),
+            field=models.CharField(choices=[('main', '主库'), ('subordinate', '从库'), ('alone', '单机')], default='', max_length=6, verbose_name='实例类型'),
         ),
         migrations.AlterField(
             model_name='db_instance',


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.